### PR TITLE
Subscribe request update

### DIFF
--- a/box_1/box_1_src/box_1_src.ino
+++ b/box_1/box_1_src/box_1_src.ino
@@ -184,6 +184,7 @@ bool timeoutPingSent = false;
 
  ******************************************************************************/
 void issueEosSubscribes()
+
 {
   // Add a filter so we don't get spammed with unwanted OSC messages from Eos
   OSCMessage filter("/eos/filter/add");
@@ -193,19 +194,14 @@ void issueEosSubscribes()
   filter.send(SLIPSerial);
   SLIPSerial.endPacket();
 
-  // subscribe to Eos pan & tilt updates
-  OSCMessage subPan("/eos/subscribe/param/pan");
+  OSCMessage subPan("/eos/subscribe/param/pan/tilt");
   subPan.add(SUBSCRIBE);
   SLIPSerial.beginPacket();
   subPan.send(SLIPSerial);
   SLIPSerial.endPacket();
 
-  OSCMessage subTilt("/eos/subscribe/param/tilt");
-  subTilt.add(SUBSCRIBE);
-  SLIPSerial.beginPacket();
-  subTilt.send(SLIPSerial);
-  SLIPSerial.endPacket();
 }
+
 
 /*******************************************************************************
    Given a valid OSCMessage (relevant to Pan/Tilt), we update our Encoder struct


### PR DESCRIPTION
We found that Eos was not returning the correct data with the previous way of requesting subscription, as per the OSC layout from ETC we changed it to.
void issueEosSubscribes()
{
  // Add a filter so we don't get spammed with unwanted OSC messages from Eos
  OSCMessage filter("/eos/filter/add");
  filter.add("/eos/out/param/*");
  filter.add("/eos/out/ping");
  SLIPSerial.beginPacket();
  filter.send(SLIPSerial);
  SLIPSerial.endPacket();

  OSCMessage subPan("/eos/subscribe/param/pan/tilt");
  subPan.add(SUBSCRIBE);
  SLIPSerial.beginPacket();
  subPan.send(SLIPSerial);
  SLIPSerial.endPacket();

}